### PR TITLE
Use correct package manager for php:7.2-apache (apt-get instead of apk)

### DIFF
--- a/multi-stage/Dockerfile
+++ b/multi-stage/Dockerfile
@@ -21,9 +21,10 @@ FROM php:7.2-apache AS release
 COPY --from=project-vendor /build /var/www/html/
 
 FROM release AS release-dev
-RUN apk add --no-cache --update --virtual buildDeps autoconf g++ make && \
+RUN export DEBIAN_FRONTEND=noninteractive && \
+    apt-get update && \
+    apt-get install -yq autoconf g++ make && \
     pecl install xdebug && \
-    docker-php-ext-enable xdebug && \
-    apk del buildDeps
+    docker-php-ext-enable xdebug
 
 FROM release


### PR DESCRIPTION
The multi-stage php-project Dockerfile uses php:7.2-apache as its base image for the 'release' stage; the 'release-dev' stage extends this image with debugging tools, but uses incorrect package manager - apk instead of apt-get - likely due to previous use of php:7.2-fpm-alpine base image. As a result the build fails.
This change-request changes the apk manager to apt-get.